### PR TITLE
Optimize bucketing

### DIFF
--- a/onmt/inputters/dynamic_iterator.py
+++ b/onmt/inputters/dynamic_iterator.py
@@ -214,6 +214,7 @@ def build_dynamic_dataset_iter(opt, transforms_cls, vocabs,
         data_iter._init_datasets(0)  # when workers=0 init_fn not called
         data_loader = data_iter
     else:
+        print('######## prefetch_factor: {}'.format(opt.prefetch_factor))
         data_loader = DataLoader(data_iter, batch_size=None,
                                  pin_memory=True,
                                  multiprocessing_context="fork",

--- a/onmt/inputters/dynamic_iterator.py
+++ b/onmt/inputters/dynamic_iterator.py
@@ -273,32 +273,27 @@ class DynamicBatchtIter(torch.utils.data.DataLoader):
         return bucket
 
     def _bucketing(self):
-        # print("####### bucketing {} examples".format(self.bucket_size))
-        # start = time.time()
-        # bucket = []
-        # for processed_ex in self.dataset_iter:
-        #     bucket.append(processed_ex)
-        #     if len(bucket) == self.bucket_size:
-        #         print("####### time to fill the bucket {}".format(
-        #             time.time() - start))
-        #         yield self._tuple_to_json_with_tokIDs(bucket)
-        #         bucket = []
-        # if bucket:
-        #     yield self._tuple_to_json_with_tokIDs(bucket)
         print("####### bucketing {} examples".format(self.bucket_size))
         start = time.time()
         bucket = []
+        _bucket_size = int(self.bucket_size/10)
+        print("#### INITIAL bucket_size: %d" % _bucket_size)
         for item in self.dataset_iter:
             processed_examples = []
             for ex in item:
                 processed_examples.append(ex)
             for ex in processed_examples:
                 bucket.append(ex)
-            if len(bucket) == self.bucket_size:
-                print("####### time to fill the bucket {}".format(
+            if len(bucket) == _bucket_size:
+                print("####### time to fill the bucket: {}".format(
                     time.time() - start))
                 yield self._tuple_to_json_with_tokIDs(bucket)
                 bucket = []
+                if _bucket_size < self.bucket_size:
+                    _bucket_size = _bucket_size * 2
+                else:
+                    _bucket_size = self.bucket_size
+                print("updated bucket_size to %d" % _bucket_size)
         if bucket:
             yield self._tuple_to_json_with_tokIDs(bucket)
 

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -632,6 +632,9 @@ def _add_train_dynamic_data(parser):
               help="""A bucket is a buffer of bucket_size examples to pick
                    from the various Corpora. The dynamic iterator batches
                    batch_size batchs from the bucket and shuffle them.""")
+    group.add("-prefetch_factor", "--prefetch_factor", type=int, default=100,
+              help="""number of mini-batches (examples) loaded in advance to avoid the
+                   GPU waiting during the refilling of the bucket.""")
 
 
 def train_opts(parser):

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -633,8 +633,8 @@ def _add_train_dynamic_data(parser):
                    from the various Corpora. The dynamic iterator batches
                    batch_size batchs from the bucket and shuffle them.""")
     group.add("-prefetch_factor", "--prefetch_factor", type=int, default=100,
-              help="""number of mini-batches (examples) loaded in advance to avoid the
-                   GPU waiting during the refilling of the bucket.""")
+              help="""number of mini-batches (examples) loaded in advance to
+                   avoid the PU waiting during the refilling of the bucket.""")
 
 
 def train_opts(parser):

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -639,7 +639,7 @@ def _add_train_dynamic_data(parser):
               type=int, default=0,
               help="""The bucket size is incremented with this
               amount of examples (optional)""")
-    group.add("-prefetch_factor", "--prefetch_factor", type=int, default=100,
+    group.add("-prefetch_factor", "--prefetch_factor", type=int, default=2,
               help="""number of mini-batches (examples) loaded in advance to
                    avoid the PU waiting during the refilling of the bucket.""")
 

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -639,6 +639,10 @@ def _add_train_dynamic_data(parser):
               type=int, default=0,
               help="""The bucket size is incremented with this
               amount of examples (optional)""")
+    group.add("-ex_batch_size", "--ex_batch_size",
+              type=int, default=1,
+              help="""The DataLoader yields mini batches with this amount of examples
+              must divide bucket_size""")
     group.add("-prefetch_factor", "--prefetch_factor", type=int, default=2,
               help="""number of mini-batches (examples) loaded in advance to
                    avoid the PU waiting during the refilling of the bucket.""")

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -632,6 +632,13 @@ def _add_train_dynamic_data(parser):
               help="""A bucket is a buffer of bucket_size examples to pick
                    from the various Corpora. The dynamic iterator batches
                    batch_size batchs from the bucket and shuffle them.""")
+    group.add("-bucket_size_init", "--bucket_size_init", type=int, default=-1,
+              help="""The bucket is initalized with this awith this
+               amount of examples (optional)""")
+    group.add("-bucket_size_increment", "--bucket_size_increment",
+              type=int, default=0,
+              help="""The bucket size is incremented with this
+              amount of examples (optional)""")
     group.add("-prefetch_factor", "--prefetch_factor", type=int, default=100,
               help="""number of mini-batches (examples) loaded in advance to
                    avoid the PU waiting during the refilling of the bucket.""")

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -8,7 +8,8 @@ from onmt.constants import CorpusTask
 from onmt.transforms import make_transforms, save_transforms, \
     get_specials, get_transforms_cls
 from onmt.inputters import build_vocab, IterOnDevice
-from onmt.inputters.dynamic_iterator import build_dynamic_dataset_iter
+from onmt.inputters.dynamic_iterator import build_dynamic_dataset_iter, \
+    build_dynamic_batch_iter
 from onmt.inputters.text_corpus import save_transformed_sample
 from onmt.model_builder import build_model
 from onmt.models.model_saver import load_checkpoint
@@ -116,7 +117,9 @@ def _build_train_iter(opt, transforms_cls, vocabs, stride=1, offset=0):
     train_iter = build_dynamic_dataset_iter(
         opt, transforms_cls, vocabs, task=CorpusTask.TRAIN,
         copy=opt.copy_attn, stride=stride, offset=offset)
-    return train_iter
+    batch_iter = build_dynamic_batch_iter(train_iter, vocabs, opt,
+                                          task=CorpusTask.TRAIN)
+    return batch_iter
 
 
 def main(opt, device_id):

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -107,8 +107,7 @@ def _get_model_opts(opt, checkpoint=None):
 def _build_valid_iter(opt, transforms_cls, vocabs):
     """Build iterator used for validation."""
     valid_iter = build_dynamic_dataset_iter(
-        opt, transforms_cls, vocabs, task=CorpusTask.VALID,
-        copy=opt.copy_attn)
+        opt, transforms_cls, vocabs, task=CorpusTask.VALID)
     return valid_iter
 
 
@@ -116,9 +115,10 @@ def _build_train_iter(opt, transforms_cls, vocabs, stride=1, offset=0):
     """Build training iterator."""
     train_iter = build_dynamic_dataset_iter(
         opt, transforms_cls, vocabs, task=CorpusTask.TRAIN,
-        copy=opt.copy_attn, stride=stride, offset=offset)
+        stride=stride, offset=offset)
     batch_iter = build_dynamic_batch_iter(train_iter, vocabs, opt,
-                                          task=CorpusTask.TRAIN)
+                                          task=CorpusTask.TRAIN,
+                                          copy=opt.copy_attn)
     return batch_iter
 
 

--- a/onmt/utils/statistics.py
+++ b/onmt/utils/statistics.py
@@ -89,7 +89,6 @@ class Statistics(object):
         self.computed_metrics = stat.computed_metrics
 
         if update_n_src_words:
-            print("updating n_src_word")
             self.n_src_words += stat.n_src_words
 
     def accuracy(self):


### PR DESCRIPTION
This PR suggests another implementation of the dynamic iterator, moving the bucket after the DataLoader, that is to say witihin the main process. In this way so that we have only one bucket per consumer and not one bucket bucket per worker as it is the case in the current implementation and what prevents us from taking full advantage of the multi-process mode of the DataLoader. This could be decisive, depending on the calculation cost of the applied transforms. This shouldn't slow the main process as the sorting/shuffling/batching of the bucket are not time consuming. However, this method is not really suitable for small datasets, as using several buckets will cause more frequent stopped iterations, which will temporarily put workers in sleep mode  and slow down the training.