### PR TITLE
Fix tensorboard logging

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -81,7 +81,7 @@ jobs:
           -train_steps 10 \
           -tensorboard "true" \
           -tensorboard_log_dir /tmp/logs_train
-        python onmt/tests/test_events.py --logdir /tmp/logs_train -m train
+        python onmt/tests/test_events.py --logdir /tmp/logs_train -tensorboard_checks train
     - name: Test RNN training and validation with copy
       run: |
         python train.py \
@@ -100,7 +100,7 @@ jobs:
           -tensorboard "true" \
           -tensorboard_log_dir /tmp/logs_train_valid \
           -copy_attn
-        python onmt/tests/test_events.py --logdir /tmp/logs_train_valid -m train_valid
+        python onmt/tests/test_events.py --logdir /tmp/logs_train_valid -tensorboard_checks train_valid
     - name: Test RNN training with coverage
       run: |
         python train.py \
@@ -167,7 +167,7 @@ jobs:
           -scoring_debug "true" \
           -tensorboard_log_dir /tmp/logs_train_metrics \
           -dump_preds /tmp/dump_preds
-        python onmt/tests/test_events.py --logdir /tmp/logs_train_metrics -m train_metrics
+        python onmt/tests/test_events.py --logdir /tmp/logs_train_metrics -tensorboard_checks train_metrics
     - name : Test Transformer training and validation with dynamic scoring
       run: |
         python3 train.py \
@@ -196,7 +196,8 @@ jobs:
           -tensorboard "true" \
           -scoring_debug "true" \
           -tensorboard_log_dir /tmp/logs_train_valid_metrics \
-        python onmt/tests/test_events.py --logdir /tmp/logs_train_valid_metrics -m train_valid_metrics 
+          -dump_preds /tmp/dump_preds
+        python onmt/tests/test_events.py --logdir /tmp/logs_train_valid_metrics -tensorboard_checks train_valid_metrics 
     - name: Test LM training
       run: |
         python train.py \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -167,7 +167,7 @@ jobs:
           -scoring_debug "true" \
           -tensorboard_log_dir /tmp/logs_train_metrics \
           -dump_preds /tmp/dump_preds
-      python onmt/tests/test_events.py --logdir /tmp/logs_train_metrics -m train_metrics
+        python onmt/tests/test_events.py --logdir /tmp/logs_train_metrics -m train_metrics
     - name : Test Transformer training and validation with dynamic scoring
       run: |
         python3 train.py \
@@ -196,7 +196,7 @@ jobs:
           -tensorboard "true" \
           -scoring_debug "true" \
           -tensorboard_log_dir /tmp/logs_train_valid_metrics \
-      python onmt/tests/test_events.py --logdir /tmp/logs_train_valid_metrics -m train_valid_metrics 
+        python onmt/tests/test_events.py --logdir /tmp/logs_train_valid_metrics -m train_valid_metrics 
     - name: Test LM training
       run: |
         python train.py \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -78,8 +78,11 @@ jobs:
           -word_vec_size 5 \
           -report_every 5\
           -hidden_size 10 \
-          -train_steps 10
-    - name: Test RNN training with copy
+          -train_steps 10 \
+          -tensorboard "true" \
+          -tensorboard_log_dir /tmp/logs_train
+        python onmt/tests/test_events.py --logdir /tmp/logs_train -m train
+    - name: Test RNN training and validation with copy
       run: |
         python train.py \
           -config data/data.yaml \
@@ -93,8 +96,11 @@ jobs:
           -word_vec_size 5 \
           -report_every 5 \
           -hidden_size 10 \
-          -train_steps 10 \
+          -train_steps 10 -valid_steps 5 \
+          -tensorboard "true" \
+          -tensorboard_log_dir /tmp/logs_train_valid \
           -copy_attn
+        python onmt/tests/test_events.py --logdir /tmp/logs_train_valid -m train_valid
     - name: Test RNN training with coverage
       run: |
         python train.py \
@@ -136,31 +142,61 @@ jobs:
     - name : Test Transformer training with dynamic scoring
       run: |
         python3 train.py \
-        -config data/data.yaml \
-        -src_vocab /tmp/onmt.vocab.src \
-        -tgt_vocab /tmp/onmt.vocab.tgt \
-        -src_vocab_size 1000 \
-        -tgt_vocab_size 1000 \
-        -encoder_type transformer \
-        -decoder_type transformer \
-        -layers 4 \
-        -word_vec_size 16 \
-        -hidden_size 16 \
-        -num_workers 0 -bucket_size 1024 \
-        -heads 2 \
-        -transformer_ff 64 \
-        -num_workers 0 -bucket_size 1024 \
-        -accum_count 2 4 8 \
-        -accum_steps 0 15000 30000 \
-        -save_model /tmp/onmt.model \
-        -train_steps 200 \
-        -report_every 50 \
-        -train_eval_steps 100 \
-        -train_metrics "BLEU" "TER" \
-        -tensorboard "true" \
-        -scoring_debug "true" \
-        -tensorboard_log_dir /tmp/logs \
-        -dump_preds /tmp/dump_preds 
+          -config data/data.yaml \
+          -src_vocab /tmp/onmt.vocab.src \
+          -tgt_vocab /tmp/onmt.vocab.tgt \
+          -src_vocab_size 1000 \
+          -tgt_vocab_size 1000 \
+          -encoder_type transformer \
+          -decoder_type transformer \
+          -layers 4 \
+          -word_vec_size 16 \
+          -hidden_size 16 \
+          -num_workers 0 -bucket_size 1024 \
+          -heads 2 \
+          -transformer_ff 64 \
+          -num_workers 0 -bucket_size 1024 \
+          -accum_count 2 4 8 \
+          -accum_steps 0 15000 30000 \
+          -save_model /tmp/onmt.model \
+          -train_steps 200 \
+          -report_every 50 \
+          -train_eval_steps 100 \
+          -train_metrics "BLEU" "TER" \
+          -tensorboard "true" \
+          -scoring_debug "true" \
+          -tensorboard_log_dir /tmp/logs_train_metrics \
+          -dump_preds /tmp/dump_preds
+      python onmt/tests/test_events.py --logdir /tmp/logs_train_metrics -m train_metrics
+    - name : Test Transformer training and validation with dynamic scoring
+      run: |
+        python3 train.py \
+          -config data/data.yaml \
+          -src_vocab /tmp/onmt.vocab.src \
+          -tgt_vocab /tmp/onmt.vocab.tgt \
+          -src_vocab_size 1000 \
+          -tgt_vocab_size 1000 \
+          -encoder_type transformer \
+          -decoder_type transformer \
+          -layers 4 \
+          -word_vec_size 16 \
+          -hidden_size 16 \
+          -num_workers 0 -bucket_size 1024 \
+          -heads 2 \
+          -transformer_ff 64 \
+          -num_workers 0 -bucket_size 1024 \
+          -accum_count 2 4 8 \
+          -accum_steps 0 15000 30000 \
+          -save_model /tmp/onmt.model \
+          -train_steps 10  -valid_steps 5 \
+          -report_every 2 \
+          -train_eval_steps 8 \
+          -train_metrics "BLEU" "TER" \
+          -valid_metrics "BLEU" "TER" \
+          -tensorboard "true" \
+          -scoring_debug "true" \
+          -tensorboard_log_dir /tmp/logs_train_valid_metrics \
+      python onmt/tests/test_events.py --logdir /tmp/logs_train_valid_metrics -m train_valid_metrics 
     - name: Test LM training
       run: |
         python train.py \

--- a/onmt/tests/pull_request_chk.sh
+++ b/onmt/tests/pull_request_chk.sh
@@ -116,7 +116,7 @@ ${PYTHON} onmt/bin/train.py \
             -hidden_size 10 -train_steps 10 \
             -tensorboard "true" \
             -tensorboard_log_dir $TMP_OUT_DIR/logs_train >> ${LOG_FILE} 2>&1
-${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train -m train
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train -tensorboard_checks train
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 rm -r $TMP_OUT_DIR/logs_train
@@ -135,7 +135,7 @@ ${PYTHON} onmt/bin/train.py \
             -tensorboard "true" \
             -tensorboard_log_dir $TMP_OUT_DIR/logs_train_valid \
             -copy_attn >> ${LOG_FILE} 2>&1
-${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_valid -m train_valid
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_valid -tensorboard_checks train_valid
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 rm -r $TMP_OUT_DIR/logs_train_valid
@@ -195,7 +195,7 @@ ${PYTHON} onmt/bin/train.py \
             -scoring_debug "true" \
             -tensorboard_log_dir $TMP_OUT_DIR/logs_train_metrics \
             -dump_preds $TMP_OUT_DIR/dump_pred >> ${LOG_FILE} 2>&1
-${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_metrics -m train_metrics
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_metrics -tensorboard_checks train_metrics
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 rm -r $TMP_OUT_DIR/logs_train_metrics
@@ -225,7 +225,7 @@ ${PYTHON} onmt/bin/train.py \
             -scoring_debug "true" \
             -dump_preds $TMP_OUT_DIR/dump_pred \
             -tensorboard_log_dir $TMP_OUT_DIR/logs_train_valid_metrics >> ${LOG_FILE} 2>&1
-${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_valid_metrics -m train_valid_metrics
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_valid_metrics -tensorboard_checks train_valid_metrics
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 rm -r $TMP_OUT_DIR/logs_train_valid_metrics

--- a/onmt/tests/pull_request_chk.sh
+++ b/onmt/tests/pull_request_chk.sh
@@ -23,6 +23,7 @@ clean_up()
         ls $TMP_OUT_DIR/*.pt | xargs -I {} rm -f $TMP_OUT_DIR/{}
     else
         # delete all .pt's
+        rm -r $TMP_OUT_DIR/dump_pred
         rm -f $TMP_OUT_DIR/*.pt
         rm -rf $TMP_OUT_DIR/sample
         rm -d $TMP_OUT_DIR
@@ -118,6 +119,7 @@ ${PYTHON} onmt/bin/train.py \
 ${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train -m train
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
+rm -r $TMP_OUT_DIR/logs_train
 
 echo -n "  [+] Testing NMT training and validation w/ copy..."
 ${PYTHON} onmt/bin/train.py \
@@ -136,6 +138,7 @@ ${PYTHON} onmt/bin/train.py \
 ${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_valid -m train_valid
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
+rm -r $TMP_OUT_DIR/logs_train_valid
 
 echo -n "  [+] Testing NMT training w/ align..."
 ${PYTHON} onmt/bin/train.py \
@@ -195,6 +198,7 @@ ${PYTHON} onmt/bin/train.py \
 ${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_metrics -m train_metrics
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
+rm -r $TMP_OUT_DIR/logs_train_metrics
 
 echo -n "  [+] Testing NMT training w/ dynamic scoring with validation ..."
 ${PYTHON} onmt/bin/train.py \
@@ -219,11 +223,12 @@ ${PYTHON} onmt/bin/train.py \
             -valid_metrics "BLEU" "TER" \
             -tensorboard "true" \
             -scoring_debug "true" \
-            -tensorboard_log_dir $TMP_OUT_DIR/logs_train_valid_metrics \
-            -dump_preds $TMP_OUT_DIR/dump_pred >> ${LOG_FILE} 2>&1
+            -dump_preds $TMP_OUT_DIR/dump_pred \
+            -tensorboard_log_dir $TMP_OUT_DIR/logs_train_valid_metrics >> ${LOG_FILE} 2>&1
 ${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_valid_metrics -m train_valid_metrics
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
+rm -r $TMP_OUT_DIR/logs_train_valid_metrics
 
 echo -n "  [+] Testing LM training..."
 ${PYTHON} onmt/bin/train.py \

--- a/onmt/tests/pull_request_chk.sh
+++ b/onmt/tests/pull_request_chk.sh
@@ -119,7 +119,7 @@ ${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train -m train
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 
-echo -n "  [+] Testing NMT training w/ copy..."
+echo -n "  [+] Testing NMT training and validation w/ copy..."
 ${PYTHON} onmt/bin/train.py \
             -config ${DATA_DIR}/data.yaml \
             -src_vocab $TMP_OUT_DIR/onmt.vocab.src \
@@ -128,9 +128,12 @@ ${PYTHON} onmt/bin/train.py \
             -tgt_vocab_size 1000 \
             -hidden_size 2 -batch_size 10 \
             -num_workers 0 -bucket_size 1024 \
-            -word_vec_size 5 -report_every 5        \
-            -hidden_size 10 -train_steps 10 \
+            -word_vec_size 5 -report_every 2 \
+            -hidden_size 10 -train_steps 10 -valid_steps 5 \
+            -tensorboard "true" \
+            -tensorboard_log_dir $TMP_OUT_DIR/logs_train_valid \
             -copy_attn >> ${LOG_FILE} 2>&1
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_valid -m train_valid
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 
@@ -192,8 +195,35 @@ ${PYTHON} onmt/bin/train.py \
 ${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_metrics -m train_metrics
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
-rm -r $TMP_OUT_DIR/dump_pred
-rm -r $TMP_OUT_DIR/logs
+
+echo -n "  [+] Testing NMT training w/ dynamic scoring with validation ..."
+${PYTHON} onmt/bin/train.py \
+            -config ${DATA_DIR}/data.yaml \
+            -src_vocab $TMP_OUT_DIR/onmt.vocab.src \
+            -tgt_vocab $TMP_OUT_DIR/onmt.vocab.tgt \
+            -src_vocab_size 1000 \
+            -tgt_vocab_size 1000 \
+            -encoder_type transformer \
+            -decoder_type transformer \
+            -layers 4 \
+            -word_vec_size 16 \
+            -hidden_size 16 \
+            -num_workers 0 -bucket_size 1024 \
+            -heads 2 \
+            -transformer_ff 64 \
+            -num_workers 0 -bucket_size 1024 \
+            -train_steps 10 \
+            -report_every 2 \
+            -train_eval_steps 8 -valid_steps 5 \
+            -train_metrics "BLEU" "TER" \
+            -valid_metrics "BLEU" "TER" \
+            -tensorboard "true" \
+            -scoring_debug "true" \
+            -tensorboard_log_dir $TMP_OUT_DIR/logs_train_valid_metrics \
+            -dump_preds $TMP_OUT_DIR/dump_pred >> ${LOG_FILE} 2>&1
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_valid_metrics -m train_valid_metrics
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
 
 echo -n "  [+] Testing LM training..."
 ${PYTHON} onmt/bin/train.py \

--- a/onmt/tests/pull_request_chk.sh
+++ b/onmt/tests/pull_request_chk.sh
@@ -111,8 +111,11 @@ ${PYTHON} onmt/bin/train.py \
             -tgt_vocab_size 1000 \
             -hidden_size 2 -batch_size 10 \
             -num_workers 0 -bucket_size 1024 \
-            -word_vec_size 5 -report_every 5        \
-            -hidden_size 10 -train_steps 10 >> ${LOG_FILE} 2>&1
+            -word_vec_size 5 -report_every 5 \
+            -hidden_size 10 -train_steps 10 \
+            -tensorboard "true" \
+            -tensorboard_log_dir $TMP_OUT_DIR/logs_train >> ${LOG_FILE} 2>&1
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train -m train
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 
@@ -184,8 +187,9 @@ ${PYTHON} onmt/bin/train.py \
             -train_metrics "BLEU" "TER" \
             -tensorboard "true" \
             -scoring_debug "true" \
-            -tensorboard_log_dir $TMP_OUT_DIR/logs \
+            -tensorboard_log_dir $TMP_OUT_DIR/logs_train_metrics \
             -dump_preds $TMP_OUT_DIR/dump_pred >> ${LOG_FILE} 2>&1
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_train_metrics -m train_metrics
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 rm -r $TMP_OUT_DIR/dump_pred

--- a/onmt/tests/test_events.py
+++ b/onmt/tests/test_events.py
@@ -10,14 +10,14 @@ class TestEvents():
         metrics = ['BLEU', 'TER']
         self.scalars = {}
         self.scalars["train"] = [('train/' + stat) for stat in stats]
+        self.scalars["train_valid"] = (self.scalars["train"] +
+                                       [('valid/' + stat) for stat in stats])
         self.scalars["train_metrics"] = (
             self.scalars["train"] +
             [('train/' + metric) for metric in metrics])
-        self.scalars["valid"] = (self.scalars["train"] +
-                                 [('valid/' + stat) for stat in stats])
         self.scalars["train_valid_metrics"] = (
-            self.scalars["train"] +
-            [('train/' + metric) for metric in metrics] +
+            self.scalars["train_metrics"] +
+            [('valid/' + stat) for stat in stats] +
             [('valid/' + metric) for metric in metrics])
 
     def reload_events(self, path):

--- a/onmt/tests/test_events.py
+++ b/onmt/tests/test_events.py
@@ -43,11 +43,11 @@ if __name__ == '__main__':
     requiredArgs = parser.add_argument_group('required arguments')
     requiredArgs.add_argument("-logdir", "--logdir", type=str, required=True)
     requiredArgs.add_argument(
-        "-m", "--method", type=str, required=True,
+        "-tensorboard_checks", "--tensorboard_checks", type=str, required=True,
         choices=["train", "train_metrics",
                  "train_valid", "train_valid_metrics"])
     args = parser.parse_args()
     test_event = TestEvents()
-    scalars = test_event.scalars[args.method]
+    scalars = test_event.scalars[args.tensorboard_checks]
     print("looking for scalars: ", scalars)
     test_event.check_scalars(scalars, args.logdir)

--- a/onmt/tests/test_events.py
+++ b/onmt/tests/test_events.py
@@ -9,12 +9,12 @@ class TestEvents():
         stats = ['xent', 'ppl', 'accuracy', 'tgtper', 'lr']
         metrics = ['BLEU', 'TER']
         self.scalars = {}
-        self.scalars["train"] = [('train/' + stat) for stat in stats]
+        self.scalars["train"] = [('progress/' + stat) for stat in stats]
         self.scalars["train_valid"] = (self.scalars["train"] +
                                        [('valid/' + stat) for stat in stats])
         self.scalars["train_metrics"] = (
             self.scalars["train"] +
-            [('train/' + metric) for metric in metrics])
+            [('progress/' + metric) for metric in metrics])
         self.scalars["train_valid_metrics"] = (
             self.scalars["train_metrics"] +
             [('valid/' + stat) for stat in stats] +

--- a/onmt/tests/test_events.py
+++ b/onmt/tests/test_events.py
@@ -1,0 +1,53 @@
+
+from tensorboard.backend.event_processing import event_accumulator
+from argparse import ArgumentParser
+import os
+
+
+class TestEvents():
+    def __init__(self):
+        stats = ['xent', 'ppl', 'accuracy', 'tgtper', 'lr']
+        metrics = ['BLEU', 'TER']
+        self.scalars = {}
+        self.scalars["train"] = [('train/' + stat) for stat in stats]
+        self.scalars["train_metrics"] = (
+            self.scalars["train"] +
+            [('train/' + metric) for metric in metrics])
+        self.scalars["valid"] = (self.scalars["train"] +
+                                 [('valid/' + stat) for stat in stats])
+        self.scalars["train_valid_metrics"] = (
+            self.scalars["train"] +
+            [('train/' + metric) for metric in metrics] +
+            [('valid/' + metric) for metric in metrics])
+
+    def reload_events(self, path):
+        ea = event_accumulator.EventAccumulator(
+            path, size_guidance={event_accumulator.SCALARS: 0},
+        )
+        ea.Reload()
+        return ea
+
+    def check_scalars(self, scalars, logdir):
+        for event_file in os.listdir(logdir):
+            path = os.path.join(logdir, event_file)
+            event_accumulator = self.reload_events(path)
+            # make sure the scalars are in the event accumulator tags
+            assert all(
+                s in event_accumulator.Tags()["scalars"] for s in scalars
+            ), "{} some scalars were not found in the event accumulator"
+
+
+if __name__ == '__main__':
+    # required arguments
+    parser = ArgumentParser()
+    requiredArgs = parser.add_argument_group('required arguments')
+    requiredArgs.add_argument("-logdir", "--logdir", type=str, required=True)
+    requiredArgs.add_argument(
+        "-m", "--method", type=str, required=True,
+        choices=["train", "train_metrics",
+                 "train_valid", "train_valid_metrics"])
+    args = parser.parse_args()
+    test_event = TestEvents()
+    scalars = test_event.scalars[args.method]
+    print("looking for scalars: ", scalars)
+    test_event.check_scalars(scalars, args.logdir)

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -270,18 +270,16 @@ class Trainer(object):
                 self.optim.learning_rate(),
                 report_stats)
             if step % self.report_manager.report_every == 0:
-                self._report_step(self.optim.learning_rate(),
-                                  step, train_stats=total_stats,
-                                  valid_stats=None)
+                self._report_validation(self.optim.learning_rate(),
+                                        step, valid_stats=None)
 
             if (valid_iter is not None and step % valid_steps == 0 and
                     self.gpu_rank <= 0):
 
                 valid_stats = self.validate(
                     valid_iter, moving_average=self.moving_average)
-                self._report_step(self.optim.learning_rate(),
-                                  step, train_stats=None,
-                                  valid_stats=valid_stats)
+                self._report_validation(self.optim.learning_rate(),
+                                        step, valid_stats=valid_stats)
 
                 # Run patience mechanism
                 if self.earlystopper is not None:
@@ -520,16 +518,14 @@ class Trainer(object):
                 report_stats,
                 multigpu=self.n_gpu > 1)
 
-    def _report_step(self, learning_rate, step, train_stats=None,
-                     valid_stats=None):
+    def _report_validation(self, learning_rate, step, valid_stats=None):
         """
         Simple function to report stats (if report_manager is set)
-        see `onmt.utils.ReportManagerBase.report_step` for doc
+        see `onmt.utils.ReportManagerBase.report_validation` for doc
         """
         if self.report_manager is not None:
-            return self.report_manager.report_step(
+            return self.report_manager.report_validation(
                 learning_rate,
                 None if self.earlystopper is None
                 else self.earlystopper.current_tolerance,
-                step, train_stats=train_stats,
-                valid_stats=valid_stats)
+                step, valid_stats=valid_stats)

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -269,6 +269,10 @@ class Trainer(object):
                 step, train_steps,
                 self.optim.learning_rate(),
                 report_stats)
+            if step % self.report_manager.report_every == 0:
+                self._report_step(self.optim.learning_rate(),
+                                  step, train_stats=total_stats,
+                                  valid_stats=None)
 
             if (valid_iter is not None and step % valid_steps == 0 and
                     self.gpu_rank == 0):
@@ -276,7 +280,7 @@ class Trainer(object):
                 valid_stats = self.validate(
                     valid_iter, moving_average=self.moving_average)
                 self._report_step(self.optim.learning_rate(),
-                                  step, train_stats=total_stats,
+                                  step, train_stats=None,
                                   valid_stats=valid_stats)
 
                 # Run patience mechanism

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -275,7 +275,7 @@ class Trainer(object):
                                   valid_stats=None)
 
             if (valid_iter is not None and step % valid_steps == 0 and
-                    self.gpu_rank == 0):
+                    self.gpu_rank <= 0):
 
                 valid_stats = self.validate(
                     valid_iter, moving_average=self.moving_average)

--- a/onmt/utils/report_manager.py
+++ b/onmt/utils/report_manager.py
@@ -32,7 +32,7 @@ class ReportMgrBase(object):
         * `_report_step`
     """
 
-    def __init__(self, report_every, train_eval_steps, start_time=-1.):
+    def __init__(self, report_every, start_time=-1.):
         """
         Args:
             report_every(int): Report status every this many sentences
@@ -40,7 +40,6 @@ class ReportMgrBase(object):
                 means that you will need to set it later or use `start()`
         """
         self.report_every = report_every
-        self.train_eval_steps = train_eval_steps
         self.start_time = start_time
 
     def start(self):
@@ -66,7 +65,7 @@ class ReportMgrBase(object):
             raise ValueError("""ReportMgr needs to be started
                                 (set 'start_time' or use 'start()'""")
 
-        if step % self.report_every == 0 or step % self.report_every == 0:
+        if step % self.report_every == 0:
             if multigpu:
                 report_stats = \
                     onmt.utils.Statistics.all_gather_stats(report_stats)
@@ -80,8 +79,8 @@ class ReportMgrBase(object):
         """ To be overridden """
         raise NotImplementedError()
 
-    def report_validation(self, lr, patience, step,
-                          valid_stats=None):
+    def report_step(self, lr, patience, step, train_stats=None,
+                    valid_stats=None):
         """
         Report stats of a step
 
@@ -92,11 +91,11 @@ class ReportMgrBase(object):
             train_stats(Statistics): training stats
             valid_stats(Statistics): validation stats
         """
-        self._report_validation(
+        self._report_step(
             lr, patience, step,
-            valid_stats=valid_stats)
+            valid_stats=valid_stats, train_stats=train_stats)
 
-    def _report_validation(self, *args, **kwargs):
+    def _report_step(self, *args, **kwargs):
         raise NotImplementedError()
 
 
@@ -128,7 +127,7 @@ class ReportMgr(ReportMgrBase):
         report_stats.output(step, num_steps,
                             learning_rate, self.start_time)
         self.maybe_log_tensorboard(report_stats,
-                                   "train",
+                                   "progress",
                                    learning_rate,
                                    patience,
                                    step)
@@ -136,11 +135,25 @@ class ReportMgr(ReportMgrBase):
 
         return report_stats
 
-    def _report_validation(self, lr, patience, step,
-                           valid_stats=None):
+    def _report_step(self, lr, patience, step,
+                     valid_stats=None, train_stats=None):
         """
         See base class method `ReportMgrBase.report_step`.
         """
+        if train_stats is not None:
+            self.log('Train perplexity: %g' % train_stats.ppl())
+            self.log('Train accuracy: %g' % train_stats.accuracy())
+            self.log('Sentences processed: %g' % train_stats.n_sents)
+            self.log('Average bsz: %4.0f/%4.0f/%2.0f' %
+                     (train_stats.n_src_words / train_stats.n_batchs,
+                      train_stats.n_words / train_stats.n_batchs,
+                      train_stats.n_sents / train_stats.n_batchs))
+
+            self.maybe_log_tensorboard(train_stats,
+                                       "train",
+                                       lr,
+                                       patience,
+                                       step)
         if valid_stats is not None:
             self.log('Validation perplexity: %g' % valid_stats.ppl())
             self.log('Validation accuracy: %g' % valid_stats.accuracy())


### PR DESCRIPTION
This PR is a patch for `tensorboard` logging failure in case where no metrics are calculated.
It includes a test to check for scalars in event files.
The validation in cpu-only mode is re-enabled and tested, as well as dynamic scoring at validation time.